### PR TITLE
Issue#5

### DIFF
--- a/cdrouter/__init__.py
+++ b/cdrouter/__init__.py
@@ -5,6 +5,6 @@
 
 """Python client for the CDRouter Web API."""
 
-__version__ = "0.5.4"
+__version__ = "0.5.5"
 
 from .cdrouter import CDRouter

--- a/setup.py
+++ b/setup.py
@@ -14,35 +14,35 @@ sys.path.insert(0, here)
 
 import cdrouter
 
-with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+with open(path.join(here, "README.rst"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    name='cdrouter',
+    name="cdrouter",
     version=cdrouter.__version__,
-    description='Python client for the CDRouter Web API',
+    description="Python client for the CDRouter Web API",
     long_description=long_description,
-    url='https://github.com/qacafe/cdrouter.py',
-    author='QA Cafe',
-    author_email='support@qacafe.com',
-    license='MIT',
+    url="https://github.com/qacafe/cdrouter.py",
+    author="QA Cafe",
+    author_email="support@qacafe.com",
+    license="MIT",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
-        'License :: OSI Approved',
-        'License :: OSI Approved :: MIT License',
-        'Intended Audience :: Developers',
+        "License :: OSI Approved",
+        "License :: OSI Approved :: MIT License",
+        "Intended Audience :: Developers",
         "Environment :: Web Environment",
         "Topic :: Software Development",
         "Operating System :: OS Independent",
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.6",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
     ],
-    keywords='cdrouter json rest api client',
-    packages=['cdrouter'],
-    install_requires=['future', 'marshmallow', 'requests', 'requests-toolbelt']
+    keywords="cdrouter json rest api client",
+    packages=["cdrouter"],
+    install_requires=["future", "marshmallow", "requests", "requests-toolbelt"],
 )

--- a/setup.py
+++ b/setup.py
@@ -8,18 +8,33 @@ from codecs import open
 from os import path
 import sys
 
+
+def read(rel_path):
+    here = path.abspath(path.dirname(__file__))
+    with open(path.join(here, rel_path), "r") as fp:
+        return fp.read()
+
+
+def get_version(rel_path):
+    for line in read(rel_path).splitlines():
+        if line.startswith("__version__"):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    else:
+        raise RuntimeError("Unable to find version string.")
+
+
 here = path.abspath(path.dirname(__file__))
 
 sys.path.insert(0, here)
 
-import cdrouter
 
 with open(path.join(here, "README.rst"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
     name="cdrouter",
-    version=cdrouter.__version__,
+    version=get_version("cdrouter/__init__.py"),
     description="Python client for the CDRouter Web API",
     long_description=long_description,
     url="https://github.com/qacafe/cdrouter.py",

--- a/setup.py
+++ b/setup.py
@@ -59,5 +59,5 @@ setup(
     ],
     keywords="cdrouter json rest api client",
     packages=["cdrouter"],
-    install_requires=["future", "marshmallow", "requests", "requests-toolbelt"],
+    install_requires=["future", "marshmallow<3", "requests", "requests-toolbelt"],
 )


### PR DESCRIPTION
This should solve issue #5 and #4 .
I had to change how the version is read from setup.py to enable installing this in my virtualenv with `pip install -e .`
The solution is taken from https://packaging.python.org/guides/single-sourcing-package-version/ - technique 1.
Prior to this change the implementation was following technique 6 and we face the highlighted installation error.
This is done in the second commit.

In the third commit I have updated the required packages list and bumped the package version.
